### PR TITLE
fix: update package exports

### DIFF
--- a/src/docshield/__init__.py
+++ b/src/docshield/__init__.py
@@ -1,16 +1,11 @@
 """DocShield: Document Authentication via Deep Learning.
 
-This package provides modules for data loading, model construction,
-training, evaluation, hyperparameter tuning, inference, explainability
-and a simple web interface.
+This package provides modules for data loading, model construction, and
+training.
 """
 
 __all__ = [
     "data",
     "models",
     "train",
-    "infer",
-    "api",
-    "ui",
-    "utils",
 ]


### PR DESCRIPTION
## Summary
- correct docshield package exports to include only existing modules
- streamline module docstring

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894f76ae1048322b8b17d7e39bd0ebc