### PR TITLE
Add training metrics and utility functions

### DIFF
--- a/src/docshield/train/metrics.py
+++ b/src/docshield/train/metrics.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+try:
+    from sklearn.metrics import accuracy_score, f1_score, precision_score, recall_score
+except Exception as exc:  # pragma: no cover - import guard
+    raise RuntimeError("scikit-learn is required for metric computation") from exc
+
+
+def compute_metrics(preds: List[int], labels: List[int]) -> Dict[str, float]:
+    """Compute accuracy, precision, recall, and macro-F1 scores.
+
+    Parameters
+    ----------
+    preds:
+        Predicted class indices.
+    labels:
+        Ground-truth class indices.
+
+    Returns
+    -------
+    Dict[str, float]
+        Dictionary containing ``accuracy``, ``precision``, ``recall``, and
+        ``f1_macro`` metrics.
+    """
+    accuracy = accuracy_score(labels, preds)
+    precision = precision_score(labels, preds, average="macro", zero_division=0)
+    recall = recall_score(labels, preds, average="macro", zero_division=0)
+    f1 = f1_score(labels, preds, average="macro", zero_division=0)
+    return {
+        "accuracy": accuracy,
+        "precision": precision,
+        "recall": recall,
+        "f1_macro": f1,
+    }

--- a/src/docshield/train/utils.py
+++ b/src/docshield/train/utils.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+import random
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+try:
+    import torch
+    import torch.nn as nn
+except Exception:  # pragma: no cover - torch may be optional during import
+    torch = None  # type: ignore
+    nn = Any  # type: ignore
+
+
+def set_seed(seed: int) -> None:
+    """Seed random number generators for reproducibility."""
+    random.seed(seed)
+    np.random.seed(seed)
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    if torch is not None:
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+
+def save_checkpoint(model: nn.Module, path: Path) -> None:
+    """Save a model's state dictionary to ``path``."""
+    if torch is None:
+        raise RuntimeError("PyTorch is required to save checkpoints")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(model.state_dict(), path)


### PR DESCRIPTION
## Summary
- add `compute_metrics` helper leveraging scikit-learn for accuracy, precision, recall and macro-F1
- add training utilities for seeding and checkpoint saving
- ensure training script imports new helper modules

## Testing
- `ruff check src/docshield/train/metrics.py src/docshield/train/utils.py`
- `black --check src/docshield/train/metrics.py src/docshield/train/utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894f769c7f0832283d6f801d85f8bab