### PR TITLE
Add placeholder evaluation and tuning scripts

### DIFF
--- a/src/docshield/train/__init__.py
+++ b/src/docshield/train/__init__.py
@@ -1,0 +1,7 @@
+"""Training utilities for DocShield.
+
+This subpackage contains scripts and helpers related to model
+training, evaluation and hyperparameter tuning.  Only a subset of the
+full project functionality is implemented in this educational
+repository.
+"""

--- a/src/docshield/train/eval.py
+++ b/src/docshield/train/eval.py
@@ -1,0 +1,34 @@
+"""Placeholder evaluation script for DocShield models.
+
+The original project performs detailed evaluation of trained models,
+including metrics such as accuracy, precision, recall and confusion
+matrices.  This lightweight placeholder merely parses command line
+arguments and prints them so that the interface exists for
+demonstration and testing purposes.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments for the evaluation script."""
+    parser = argparse.ArgumentParser(description="Evaluate a DocShield model (placeholder)")
+    parser.add_argument("--config", type=str, help="Path to a training configuration file", required=False)
+    parser.add_argument("--checkpoint", type=str, help="Path to a model checkpoint", required=False)
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Entry point for placeholder evaluation."""
+    args = parse_args()
+    print("Evaluation placeholder invoked.")
+    if args.config:
+        print(f"Config: {args.config}")
+    if args.checkpoint:
+        print(f"Checkpoint: {args.checkpoint}")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/src/docshield/train/tune.py
+++ b/src/docshield/train/tune.py
@@ -1,0 +1,31 @@
+"""Placeholder hyperparameter tuning script for DocShield models.
+
+In the full implementation the project uses Optuna to search over a
+set of hyperparameters.  Here we provide a small shim that exposes the
+expected command line interface without performing actual optimisation.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments for the tuning script."""
+    parser = argparse.ArgumentParser(description="Hyperparameter tuning for DocShield (placeholder)")
+    parser.add_argument("--config", type=str, help="Path to a training configuration file", required=False)
+    parser.add_argument("--trials", type=int, default=1, help="Number of trials to run")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Entry point for placeholder tuning."""
+    args = parse_args()
+    print("Tuning placeholder invoked.")
+    if args.config:
+        print(f"Config: {args.config}")
+    print(f"Trials: {args.trials}")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()


### PR DESCRIPTION
## Summary
- add `src.docshield.train` package with minimal `__init__`
- implement placeholder `eval.py` and `tune.py` CLI scripts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894f76ce20c83229e0fc86ef0ebd0f2